### PR TITLE
Deleted AGG submodule and disabled code relying on AGG.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
 [submodule "submodules/libopencm3"]
 	path = submodules/libopencm3
 	url = https://github.com/libopencm3/libopencm3
-[submodule "submodules/agg"]
-	path = submodules/agg
-	url = https://github.com/tomhughes/agg
-	branch = 2.4

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,8 @@
        HOSTCXX := c++
         HOSTLD := c++
 
-    SUBMODULES := libopencm3 agg
+    SUBMODULES := libopencm3
    OPENCM3_DIR := submodules/libopencm3
-       AGG_DIR := submodules/agg
 
       CPPFLAGS := -DSTM32F4
       CPPFLAGS += -Isrc -Iinclude -I$(OPENCM3_DIR)/include
@@ -28,10 +27,10 @@
  EXAMPLE_ELVES :=
 
 
-all: opencm3 agg lib examples
+all: opencm3 lib examples
 
 include src/Dir.make
-include pixmaps/Dir.make
+#include pixmaps/Dir.make
 include examples/Dir.make
 
 clean:
@@ -39,31 +38,16 @@ clean:
 
 realclean: clean
 	$(MAKE) -C $(OPENCM3_DIR) clean
-	$(MAKE) -C $(AGG_DIR) clean
-	$(MAKE) -C $(AGG_DIR)/examples/macosx_sdl clean
-	find $(AGG_DIR) -name '*.o' -exec rm -f '{}' ';'
 
 opencm3:
 #       # XXX libopencm3 can't stop rebuilding the world.
 	@ [ -f $(OPENCM3_DIR)/lib/libopencm3_stm32f4.a ] || \
 	  $(MAKE) -C $(OPENCM3_DIR) TARGETS=stm32/f4
 
-agg:
-#	# XXX submake is too noisy.
-	@ $(MAKE) -s -C $(AGG_DIR) --no-print-directory
-	@ $(MAKE) -s                                                    \
-	          -C $(AGG_DIR)/examples/macosx_sdl                     \
-	          --no-print-directory                                  \
-	          freetype
-
 examples: $(EXAMPLE_ELVES)
 
 ifeq ($(wildcard $(OPENCM3_DIR)/*),)
     missing_submodule := libopencm3
-endif
-
-ifeq ($(wildcard $(AGG_DIR)/*),)
-    missing_submodule := agg
 endif
 
 ifdef missing_submodule

--- a/examples/Dir.make
+++ b/examples/Dir.make
@@ -1,5 +1,6 @@
        D := examples
 
-EXAMPLES := button line-test munch simple touch
+EXAMPLES := munch simple touch
+#EXAMPLES += line-test button # disabled for now
 
 include $(EXAMPLES:%=$D/%/Dir.make)


### PR DESCRIPTION
AGG was causing issues when trying to compile on linux because of libfreetype lib include path issues. @kbob mentioned that we are actually only using AGG for libfreetype so I think we should disable agg and port the code that was using agg to use libfreetype directly and include libfreetype as a submodule to gain control over that dependency.

The code relying on AGG needs to be ported to use libfreetype directly.
We can add libfreetype as a sumbodule to prevent having uncontrolled
external dependencies.